### PR TITLE
Fixed string search for x64 modules and registration

### DIFF
--- a/amdocl.bat
+++ b/amdocl.bat
@@ -120,7 +120,7 @@ for /r %%f in (amdocl*dll) do (
         if "%%~nxf"=="%%A" (
             echo Found: !FILE!
 
-            echo !FILE! | findstr /C:"64" >nul
+            echo !FILE! | findstr /C:"cl64" >nul
             if !ERRORLEVEL! == 0 (
                 set "ROOTKEY=!ROOTKEY64!"
             ) else (

--- a/amdocl.bat
+++ b/amdocl.bat
@@ -120,7 +120,7 @@ for /r %%f in (amdocl*dll) do (
         if "%%~nxf"=="%%A" (
             echo Found: !FILE!
 
-            echo !FILE! | findstr /C:"_amd64_" >nul
+            echo !FILE! | findstr /C:"64" >nul
             if !ERRORLEVEL! == 0 (
                 set "ROOTKEY=!ROOTKEY64!"
             ) else (


### PR DESCRIPTION
line #123 is a simple string search against a filename, `_amd64_` is not listed in any filename in System32 and always gets ignored during the fast scan. The value is changed to `cl64` as this will automatically detect the x64 versions vs the x32 reliably, regardless of the PATH.. this should allow the fast and full scan to register the files properly

however this is only true if cl64 is appended to all x64 dlls that AMD issues, which I am only 99% sure is the case.. Even though I believe this to be true I can't fully confirm it, so I defer to you..